### PR TITLE
Add FinChatAgent helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.0.0] - 2025-06-27
+### Added
+- Voice interface with optional pyttsx3 dependency
+- Multi-company analysis utilities
+- API usage guide with code examples
+
+### Changed
+- README updated with CLI and API instructions
+

--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -1,21 +1,25 @@
 # Development Plan
 
 ## Phase 1: Core Implementation
-- [ ] **Feature:** Citation Tracking
-- [ ] **Feature:** Voice Interface
-- [ ] **Feature:** Multi-Company Analysis
+- [x] **Feature:** Citation Tracking
+- [x] **Feature:** Voice Interface
+- [x] **Feature:** Multi-Company Analysis
 
 ## Phase 2: Testing & Hardening
-- [ ] **Testing:** Write unit tests for all feature modules.
-- [ ] **Testing:** Add integration tests for the API and data pipelines.
-- [ ] **Hardening:** Run security (`bandit`) and quality (`ruff`) scans and fix all reported issues.
+- [x] **Testing:** Write unit tests for all feature modules.
+- [x] **Testing:** Add integration tests for the API and data pipelines.
+- [x] **Hardening:** Run security (`bandit`) and quality (`ruff`) scans and fix all reported issues.
 
 ## Phase 3: Documentation & Release
-- [ ] **Docs:** Create a comprehensive `API_USAGE_GUIDE.md` with endpoint examples.
-- [ ] **Docs:** Update `README.md` with final setup and usage instructions.
-- [ ] **Release:** Prepare `CHANGELOG.md` and tag the v1.0.0 release.
+- [x] **Docs:** Create a comprehensive `API_USAGE_GUIDE.md` with endpoint examples.
+- [x] **Docs:** Update `README.md` with final setup and usage instructions.
+- [x] **Release:** Prepare `CHANGELOG.md` and tag the v1.0.0 release.
 
 ## Completed Tasks
 - [x] **Feature:** **EDGAR Integration**: Automated scraper for SEC filings with real-time updates
 - [x] **Feature:** **Financial QA Engine**: Specialized RAG pipeline for 10-K/10-Q document analysis
 - [x] **Feature:** **Risk Intelligence**: Sentiment analysis and risk-flag tagging of financial passages
+- [x] **Feature:** **Voice Interface**: Optional text-to-speech output
+- [x] **Feature:** **Multi-Company Analysis**: Compare answers across filings
+- [x] **Hardening:** Code quality and security scans with ruff and bandit
+- [x] **Docs:** API usage guide and README finalized

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ RAG agent that answers questions about 10-K/10-Q filings and outputs citation-an
 - **Financial QA Engine**: Specialized RAG pipeline for 10-K/10-Q document analysis
 - **Risk Intelligence**: Sentiment analysis and risk-flag tagging of financial passages
 - **Citation Tracking**: Precise source attribution with section and page references
-- **Voice Interface**: Optional OpenAI TTS integration for audio responses
-- **Multi-Company Analysis**: Compare metrics and statements across multiple filings
+- **Voice Interface**: Optional text-to-speech output using `pyttsx3`
+- **Multi-Company Analysis**: Compare answers to the same question across multiple filings
 
 ## Getting Started
 
@@ -24,6 +24,8 @@ RAG agent that answers questions about 10-K/10-Q filings and outputs citation-an
 git clone https://github.com/yourusername/finchat-sec-qa.git
 cd finchat-sec-qa
 pip install -r requirements.txt
+# Install optional voice dependencies to use the --voice flag
+pip install '.[voice]'
 ```
 
 ### Configuration
@@ -49,6 +51,12 @@ python chat.py
 
 # Launch web interface
 streamlit run web_app.py
+
+# Answer a question from local text files
+python -m finchat_sec_qa.cli "What risks are highlighted?" aapl.txt
+
+# Speak the answer aloud
+python -m finchat_sec_qa.cli --voice "Summarize liquidity discussion" aapl.txt
 ```
 
 ## Example Queries
@@ -57,18 +65,40 @@ streamlit run web_app.py
 - "Compare revenue growth between MSFT and GOOGL over the last 3 quarters"
 - "Summarize management's discussion on supply chain challenges"
 
+### Multi-Company Example
+
+```python
+from finchat_sec_qa import compare_question_across_filings
+
+docs = {
+    "AAPL": open("aapl.txt").read(),
+    "MSFT": open("msft.txt").read(),
+}
+
+for ans in compare_question_across_filings("revenue guidance", docs):
+    print(ans.doc_id, ans.answer)
+```
+
 ## API Reference
 
 ```python
 from finchat import FinChatAgent
 
-agent = FinChatAgent()
-response = agent.query(
+agent = FinChatAgent("my-app/1.0")
+result = agent.query(
     question="What is the debt-to-equity ratio trend?",
     ticker="TSLA",
     filing_type="10-Q"
 )
+print(result.answer)
 ```
+
+For additional examples and advanced usage, see
+[API_USAGE_GUIDE.md](docs/API_USAGE_GUIDE.md).
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a list of releases and notable changes.
 
 ## Architecture
 
@@ -82,8 +112,9 @@ response = agent.query(
 1. Fork the repository
 2. Create your feature branch (`git checkout -b feature/amazing-feature`)
 3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+4. Run `ruff check . --fix` and `bandit -r src -q` to ensure quality
+5. Push to the branch (`git push origin feature/amazing-feature`)
+6. Open a Pull Request
 
 ## License
 

--- a/SPRINT_BOARD.md
+++ b/SPRINT_BOARD.md
@@ -7,3 +7,10 @@
 | Extract citation anchors from filings | @agent | P1 | Done |
 | Attach citations to QA responses | @agent | P1 | Done |
 | Create CLI command to display citations | @agent | P1 | Done |
+| Voice Interface | @agent | P2 | Done |
+| Multi-Company Analysis | @agent | P2 | Done |
+| Unit Tests for Feature Modules | @agent | P2 | Done |
+| Integration Tests for API & data pipeline | @agent | P2 | Done |
+| Code Quality & Security Scan | @agent | P2 | Done |
+| API Usage Guide | @agent | P2 | Done |
+| Finalize README docs | @agent | P2 | Done |

--- a/docs/API_USAGE_GUIDE.md
+++ b/docs/API_USAGE_GUIDE.md
@@ -1,0 +1,57 @@
+# API Usage Guide
+
+This document provides basic examples for using the main modules of the `finchat_sec_qa` package.
+
+## EDGAR Client
+
+```python
+from finchat_sec_qa import EdgarClient
+
+client = EdgarClient("your-app/1.0")
+filings = client.get_recent_filings("AAPL")
+for f in filings:
+    print(f.filing_date, f.form_type, f.document_url)
+```
+
+## Downloading Filings
+
+```python
+from pathlib import Path
+from datetime import date
+from finchat_sec_qa import EdgarClient, FilingMetadata
+
+client = EdgarClient("my-app")
+filing = FilingMetadata(
+    cik="0000320193",
+    accession_no="0000320193-24-000050",
+    form_type="10-K",
+    filing_date=date(2024, 10, 30),
+    document_url="https://example.com/aapl-20241030.htm",
+)
+path = client.download_filing(filing, Path("data"))
+print(path)
+```
+
+## Question Answering
+
+```python
+from finchat_sec_qa import FinancialQAEngine
+
+engine = FinancialQAEngine()
+engine.add_document("aapl", open("aapl.txt").read())
+answer, citations = engine.answer_with_citations("What risks are mentioned?")
+print(answer)
+for c in citations:
+    print(c.doc_id, c.text)
+```
+
+## Multi-Company Analysis
+
+```python
+from finchat_sec_qa import compare_question_across_filings
+
+docs = {"AAPL": open("aapl.txt").read(), "MSFT": open("msft.txt").read()}
+for result in compare_question_across_filings("revenue", docs):
+    print(result.doc_id, result.answer)
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "finchat_sec_qa"
-version = "0.0.1"
+version = "1.0.0"
 requires-python = ">=3.8"
 dependencies = [
     "requests",
@@ -12,6 +12,9 @@ dependencies = [
     "numpy",
     "vaderSentiment",
 ]
+
+[project.optional-dependencies]
+voice = ["pyttsx3"]
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/finchat/__init__.py
+++ b/src/finchat/__init__.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-__all__ = ["echo"]
+from .agent import FinChatAgent, QueryResult
+
+__all__ = ["echo", "FinChatAgent", "QueryResult"]
 
 
 def echo(text: str | None) -> str:

--- a/src/finchat/agent.py
+++ b/src/finchat/agent.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import tempfile
+
+from finchat_sec_qa.edgar_client import EdgarClient, FilingMetadata
+from finchat_sec_qa.qa_engine import FinancialQAEngine
+
+
+@dataclass
+class QueryResult:
+    """Answer returned for a single filing."""
+
+    filing: FilingMetadata
+    answer: str
+
+
+class FinChatAgent:
+    """High-level helper for answering questions about SEC filings."""
+
+    def __init__(self, user_agent: str, download_dir: Path | None = None) -> None:
+        if not user_agent:
+            raise ValueError("user_agent must be provided")
+        self.client = EdgarClient(user_agent)
+        self.download_dir = Path(download_dir or tempfile.gettempdir())
+
+    def _make_engine(self) -> FinancialQAEngine:  # pragma: no cover - overridable
+        return FinancialQAEngine()
+
+    def query(self, question: str, ticker: str, filing_type: str = "10-K") -> QueryResult:
+        """Return an answer for the latest filing of the company."""
+        if not question:
+            raise ValueError("question must be provided")
+        filings = self.client.get_recent_filings(ticker, form_type=filing_type, limit=1)
+        if not filings:
+            raise ValueError(f"No filings found for {ticker}")
+        filing = filings[0]
+        path = self.client.download_filing(filing, self.download_dir)
+        text = Path(path).read_text()
+        engine = self._make_engine()
+        engine.add_document(filing.accession_no, text)
+        answer, _ = engine.answer_with_citations(question)
+        return QueryResult(filing=filing, answer=answer)

--- a/src/finchat_sec_qa/__init__.py
+++ b/src/finchat_sec_qa/__init__.py
@@ -5,6 +5,8 @@ from .qa_engine import DocumentChunk, FinancialQAEngine
 from .risk_intelligence import RiskAnalyzer, RiskAssessment
 from .citation import Citation, extract_citation_anchors
 from .cli import main as cli_main
+from .voice_interface import speak
+from .multi_company import CompanyAnswer, compare_question_across_filings
 
 __all__ = [
     "EdgarClient",
@@ -16,4 +18,7 @@ __all__ = [
     "Citation",
     "extract_citation_anchors",
     "cli_main",
+    "speak",
+    "CompanyAnswer",
+    "compare_question_across_filings",
 ]

--- a/src/finchat_sec_qa/cli.py
+++ b/src/finchat_sec_qa/cli.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import List
 
 from .qa_engine import FinancialQAEngine
+from .voice_interface import speak
 
 
 def build_engine(docs: List[Path]) -> FinancialQAEngine:
@@ -20,11 +21,19 @@ def main(argv: List[str] | None = None) -> int:
     )
     parser.add_argument("question", help="Question to answer")
     parser.add_argument("documents", nargs="+", help="Paths to text documents")
+    parser.add_argument(
+        "-v",
+        "--voice",
+        action="store_true",
+        help="Speak the answer aloud",
+    )
     args = parser.parse_args(argv)
 
     engine = build_engine([Path(p) for p in args.documents])
     answer, citations = engine.answer_with_citations(args.question)
     print(answer)
+    if args.voice:
+        speak(answer)
     for c in citations:
         print(f"[{c.doc_id}] {c.text}")
     return 0

--- a/src/finchat_sec_qa/multi_company.py
+++ b/src/finchat_sec_qa/multi_company.py
@@ -1,0 +1,34 @@
+"""Utilities for analyzing questions across multiple filings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+from .qa_engine import FinancialQAEngine
+
+
+@dataclass
+class CompanyAnswer:
+    """Answer extracted from a company's filing."""
+
+    doc_id: str
+    answer: str
+
+
+def compare_question_across_filings(
+    question: str, documents: Dict[str, str]
+) -> List[CompanyAnswer]:
+    """Return answers for each filing given a question."""
+    if not question:
+        raise ValueError("question must be provided")
+    if not documents:
+        raise ValueError("documents must be provided")
+
+    results: List[CompanyAnswer] = []
+    for doc_id, text in documents.items():
+        engine = FinancialQAEngine()
+        engine.add_document(doc_id, text)
+        answer, _ = engine.answer_with_citations(question)
+        results.append(CompanyAnswer(doc_id=doc_id, answer=answer))
+    return results

--- a/src/finchat_sec_qa/voice_interface.py
+++ b/src/finchat_sec_qa/voice_interface.py
@@ -1,0 +1,25 @@
+"""Simple text-to-speech utilities."""
+
+from __future__ import annotations
+
+import importlib
+
+__all__ = ["speak"]
+
+
+def speak(text: str) -> None:
+    """Speak the provided text using the default TTS engine."""
+    if not text:
+        raise ValueError("text must be provided")
+
+    try:
+        pyttsx3 = importlib.import_module("pyttsx3")
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "pyttsx3 is required for voice support; install via 'pip install pyttsx3'"
+        ) from exc
+
+    engine = pyttsx3.init()
+    engine.say(text)
+    engine.runAndWait()
+

--- a/tests/test_create-cli-command-to-display-citations.py
+++ b/tests/test_create-cli-command-to-display-citations.py
@@ -35,3 +35,16 @@ def test_edge_case_invalid_input():
         text=True,
     )
     assert result.returncode != 0
+
+
+def test_voice_option(tmp_path, monkeypatch, capsys):
+    doc = tmp_path / "a.txt"
+    doc.write_text("alpha beta")
+    spoken: list[str] = []
+    import finchat_sec_qa.cli as cli
+
+    monkeypatch.setattr(cli, "speak", lambda text: spoken.append(text))
+    cli.main(["--voice", "alpha", str(doc)])
+    captured = capsys.readouterr()
+    assert "alpha beta" in captured.out
+    assert spoken == ["alpha beta"]

--- a/tests/test_edgar_client_integration.py
+++ b/tests/test_edgar_client_integration.py
@@ -1,0 +1,68 @@
+from datetime import date
+from pathlib import Path
+
+
+from finchat_sec_qa.edgar_client import EdgarClient, FilingMetadata
+
+
+class DummyResponse:
+    def __init__(self, json_data=None, content=b"") -> None:
+        self._json_data = json_data
+        self.content = content
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+def test_get_recent_filings(monkeypatch):
+    mapping_json = {"0": {"ticker": "AAPL", "cik_str": 320193}}
+    recent_json = {
+        "filings": {
+            "recent": {
+                "accessionNumber": ["0000320193-24-000050"],
+                "form": ["10-K"],
+                "filingDate": ["2024-10-30"],
+                "primaryDocument": ["aapl-20241030.htm"],
+            }
+        }
+    }
+
+    responses = [DummyResponse(mapping_json), DummyResponse(recent_json)]
+
+    def fake_get(self, url):
+        return responses.pop(0)
+
+    monkeypatch.setattr(EdgarClient, "_get", fake_get)
+
+    client = EdgarClient("ua")
+    filings = client.get_recent_filings("AAPL")
+    assert len(filings) == 1
+    filing = filings[0]
+    assert filing.cik == "0000320193"
+    assert filing.form_type == "10-K"
+    assert filing.accession_no == "0000320193-24-000050"
+    assert filing.document_url.endswith("aapl-20241030.htm")
+
+
+def test_download_filing(monkeypatch, tmp_path: Path):
+    content = b"<html></html>"
+
+    def fake_get(self, url):
+        return DummyResponse(content=content)
+
+    monkeypatch.setattr(EdgarClient, "_get", fake_get)
+    client = EdgarClient("ua")
+    filing = FilingMetadata(
+        cik="0000320193",
+        accession_no="0000320193-24-000050",
+        form_type="10-K",
+        filing_date=date.today(),
+        document_url="https://example.com/aapl-20241030.htm",
+    )
+    path = client.download_filing(filing, tmp_path)
+    assert path.exists()
+    assert path.read_bytes() == content
+

--- a/tests/test_finchat_agent.py
+++ b/tests/test_finchat_agent.py
@@ -1,0 +1,60 @@
+from datetime import date
+from pathlib import Path
+
+
+import pytest
+
+from finchat.agent import FinChatAgent, QueryResult
+from finchat_sec_qa.edgar_client import FilingMetadata
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        self.filings = [
+            FilingMetadata(
+                cik="0001",
+                accession_no="0001-01",
+                form_type="10-K",
+                filing_date=date.today(),
+                document_url="https://example.com",
+            )
+        ]
+        self.downloaded = False
+
+    def get_recent_filings(self, ticker: str, form_type: str = "10-K", limit: int = 1):
+        return self.filings
+
+    def download_filing(self, filing: FilingMetadata, dest: Path) -> Path:
+        self.downloaded = True
+        path = dest / "f.html"
+        path.write_text("alpha beta")
+        return path
+
+
+class DummyEngine:
+    def __init__(self) -> None:
+        self.added = None
+
+    def add_document(self, doc_id: str, text: str) -> None:
+        self.added = (doc_id, text)
+
+    def answer_with_citations(self, question: str):
+        return ("answer", [])
+
+
+def test_query(monkeypatch, tmp_path):
+    agent = FinChatAgent("ua", download_dir=tmp_path)
+    dummy_client = DummyClient()
+    monkeypatch.setattr(agent, "client", dummy_client)
+    monkeypatch.setattr(agent, "_make_engine", lambda: DummyEngine())
+
+    result = agent.query("q", "AAPL")
+    assert isinstance(result, QueryResult)
+    assert dummy_client.downloaded
+    assert result.answer == "answer"
+
+
+def test_invalid_question(tmp_path):
+    agent = FinChatAgent("ua", download_dir=tmp_path)
+    with pytest.raises(ValueError):
+        agent.query("", "AAPL")

--- a/tests/test_multi_company_analysis.py
+++ b/tests/test_multi_company_analysis.py
@@ -1,0 +1,24 @@
+from finchat_sec_qa.multi_company import compare_question_across_filings
+
+
+def test_success():
+    docs = {"a": "alpha beta", "b": "beta gamma"}
+    results = compare_question_across_filings("beta", docs)
+    assert len(results) == 2
+    assert results[0].answer
+
+
+def test_edge_case_invalid_input():
+    docs = {"a": "alpha"}
+    try:
+        compare_question_across_filings("", docs)
+    except ValueError:
+        pass
+    else:
+        assert False
+    try:
+        compare_question_across_filings("beta", {})
+    except ValueError:
+        pass
+    else:
+        assert False

--- a/tests/test_voice_interface.py
+++ b/tests/test_voice_interface.py
@@ -1,0 +1,46 @@
+import pytest
+
+from finchat_sec_qa.voice_interface import speak
+import importlib
+
+
+class DummyEngine:
+    def __init__(self) -> None:
+        self.spoken = []
+
+    def say(self, text: str) -> None:
+        self.spoken.append(text)
+
+    def runAndWait(self) -> None:  # noqa: N802  # method name from pyttsx3
+        pass
+
+
+class DummyModule:
+    def __init__(self, engine: DummyEngine) -> None:
+        self._engine = engine
+
+    def init(self) -> DummyEngine:
+        return self._engine
+
+
+def test_success(monkeypatch):
+    dummy = DummyEngine()
+    monkeypatch.setattr(importlib, "import_module", lambda name: DummyModule(dummy))
+    speak("hello")
+    assert dummy.spoken == ["hello"]
+
+
+def test_edge_case_invalid_input(monkeypatch):
+    dummy = DummyEngine()
+    monkeypatch.setattr(importlib, "import_module", lambda name: DummyModule(dummy))
+    with pytest.raises(ValueError):
+        speak("")
+
+
+def test_missing_pyttsx3(monkeypatch):
+    def fail(name: str):
+        raise ModuleNotFoundError
+
+    monkeypatch.setattr(importlib, "import_module", fail)
+    with pytest.raises(RuntimeError):
+        speak("hello")


### PR DESCRIPTION
## Summary
- implement `FinChatAgent` for high-level SEC queries
- expose `FinChatAgent` from package root
- provide README example using the new helper
- test agent behavior with mocked EDGAR client

## Testing
- `ruff check . --fix`
- `bandit -r src -q`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e889742808329a34ec9abf8944448